### PR TITLE
Share the benchmark setup

### DIFF
--- a/benches/time.rs
+++ b/benches/time.rs
@@ -108,9 +108,10 @@ fn benchmark_seahash(c: &mut Criterion) {
 fn benchmark_enrichment_tables_file(c: &mut Criterion) {
     let mut group = c.benchmark_group("enrichment_tables_file");
     group.bench_function("enrichment_tables/file_noindex_10", |b| {
+        let (file, _index, condition, expected) = setup(10);
         b.iter_batched(
-            || setup(10),
-            |(file, _index, condition, expected)| {
+            || (&file, condition.clone(), expected.clone()),
+            |(file, condition, expected)| {
                 assert_eq!(Ok(expected), file.find_table_row(condition, None))
             },
             BatchSize::SmallInput,
@@ -118,8 +119,9 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
     });
 
     group.bench_function("enrichment_tables/file_hashindex_10", |b| {
+        let (file, index, condition, expected) = setup(10);
         b.iter_batched(
-            || setup(10),
+            || (&file, index.clone(), condition.clone(), expected.clone()),
             |(file, index, condition, expected)| {
                 assert_eq!(Ok(expected), file.find_table_row(condition, Some(index)))
             },
@@ -128,9 +130,10 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
     });
 
     group.bench_function("enrichment_tables/file_noindex_1_000", |b| {
+        let (file, _index, condition, expected) = setup(1_000);
         b.iter_batched(
-            || setup(1_000),
-            |(file, _index, condition, expected)| {
+            || (&file, condition.clone(), expected.clone()),
+            |(file, condition, expected)| {
                 assert_eq!(Ok(expected), file.find_table_row(condition, None))
             },
             BatchSize::SmallInput,
@@ -138,8 +141,9 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
     });
 
     group.bench_function("enrichment_tables/file_hashindex_1_000", |b| {
+        let (file, index, condition, expected) = setup(1_000);
         b.iter_batched(
-            || setup(1_000),
+            || (&file, index.clone(), condition.clone(), expected.clone()),
             |(file, index, condition, expected)| {
                 assert_eq!(Ok(expected), file.find_table_row(condition, Some(index)))
             },
@@ -148,9 +152,10 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
     });
 
     group.bench_function("enrichment_tables/file_noindex_10_000", |b| {
+        let (file, _index, condition, expected) = setup(10_000);
         b.iter_batched(
-            || setup(10_000),
-            |(file, _index, condition, expected)| {
+            || (&file, condition.clone(), expected.clone()),
+            |(file, condition, expected)| {
                 assert_eq!(Ok(expected), file.find_table_row(condition, None))
             },
             BatchSize::SmallInput,
@@ -158,8 +163,9 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
     });
 
     group.bench_function("enrichment_tables/file_hashindex_10_000", |b| {
+        let (file, index, condition, expected) = setup(10_000);
         b.iter_batched(
-            || setup(10_000),
+            || (&file, index.clone(), condition.clone(), expected.clone()),
             |(file, index, condition, expected)| {
                 assert_eq!(Ok(expected), file.find_table_row(condition, Some(index)))
             },
@@ -168,9 +174,10 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
     });
 
     group.bench_function("enrichment_tables/file_noindex_1_000_000", |b| {
+        let (file, _index, condition, expected) = setup(1_000_000);
         b.iter_batched(
-            || setup(1_000_000),
-            |(file, _index, condition, expected)| {
+            || (&file, condition.clone(), expected.clone()),
+            |(file, condition, expected)| {
                 assert_eq!(Ok(expected), file.find_table_row(condition, None))
             },
             BatchSize::SmallInput,
@@ -178,8 +185,9 @@ fn benchmark_enrichment_tables_file(c: &mut Criterion) {
     });
 
     group.bench_function("enrichment_tables/file_hashindex_1_000_000", |b| {
+        let (file, index, condition, expected) = setup(1_000_000);
         b.iter_batched(
-            || setup(1_000_000),
+            || (&file, index.clone(), condition.clone(), expected.clone()),
             |(file, index, condition, expected)| {
                 assert_eq!(Ok(expected), file.find_table_row(condition, Some(index)))
             },


### PR DESCRIPTION
To avoid timing the drop of `file` in each iteration. Also speeds up the
benchmark setup generally. I don't _think_ there is a reason to set this
up once for each iteration?

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>